### PR TITLE
Add Docker Compose environment with SQL Server database

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+.DS_Store
+.nuxt
+.output
+.git
+.gitignore
+dist
+coverage
+.idea
+.vscode
+*.local

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Application
+NODE_ENV=development
+
+# Database connection settings
+DB_SERVER=db
+DB_PORT=1433
+DB_NAME=gates
+DB_USER=gates_user
+DB_PASS=GatesUser!Pass123
+
+# SQL Server admin password used by docker-compose
+SA_PASSWORD=YourStrong!Passw0rd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use a multi-stage build to support both development and production workflows
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+# Install dependencies first to leverage Docker layer caching
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the application source
+COPY . .
+
+# -------- Development image --------
+FROM base AS dev
+ENV NODE_ENV=development
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+
+# -------- Production build --------
+FROM base AS build
+ENV NODE_ENV=production
+RUN npm run build
+
+FROM node:20-alpine AS production
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Copy only what we need for production runtime
+COPY --from=base /app/package*.json ./
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=build /app/.output ./.output
+
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ Når de korrekte avhengigheter er innstallert kjøres applikasjonen ved kommando
 
 
 
+# Docker-basert utviklingsmiljø
+
+Prosjektet kan nå kjøres lokalt med Docker og Docker Compose. Dette starter både applikasjonen og en SQL Server-instans med en ferdig konfigurert database.
+
+1. Kopier `.env.example` til `.env` og juster eventuelle variabler ved behov.
+2. Start miljøet med:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Tjenesten er tilgjengelig på [http://localhost:3000](http://localhost:3000) når byggingen er ferdig.
+
+Compose-oppsettet oppretter databasen `gates` med brukeren `gates_user`. Miljøvariablene `DB_SERVER`, `DB_NAME`, `DB_USER`, `DB_PASS` og `DB_PORT` brukes av Nuxt-applikasjonen for å koble til databasen. Standardverdiene fungerer direkte mot Docker Compose-konfigurasjonen.
+
+
+
 # Nuxt 3 Minimal Starter
 
 Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      target: dev
+    command: npm run dev -- --host 0.0.0.0
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+      DB_SERVER: db
+      DB_USER: ${DB_USER:-gates_user}
+      DB_PASS: ${DB_PASS:-GatesUser!Pass123}
+      DB_NAME: ${DB_NAME:-gates}
+      DB_PORT: ${DB_PORT:-1433}
+    volumes:
+      - .:/app
+      - /app/node_modules
+    depends_on:
+      db:
+        condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Express"
+      SA_PASSWORD: ${SA_PASSWORD:-YourStrong!Passw0rd}
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $$SA_PASSWORD -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  db-init:
+    image: mcr.microsoft.com/mssql-tools
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD:-YourStrong!Passw0rd}
+    volumes:
+      - ./docker/sqlserver/init.sql:/init.sql:ro
+    entrypoint: ["/bin/bash", "-c", "/opt/mssql-tools/bin/sqlcmd -S db -U sa -P \"$SA_PASSWORD\" -d master -i /init.sql"]
+    restart: "no"
+
+volumes:
+  mssql-data:

--- a/docker/sqlserver/init.sql
+++ b/docker/sqlserver/init.sql
@@ -1,0 +1,33 @@
+IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = N'gates')
+BEGIN
+    CREATE DATABASE [gates];
+END;
+GO
+
+USE [gates];
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.server_principals WHERE name = N'gates_user')
+BEGIN
+    CREATE LOGIN [gates_user] WITH PASSWORD = 'GatesUser!Pass123';
+END;
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'gates_user')
+BEGIN
+    CREATE USER [gates_user] FOR LOGIN [gates_user];
+END;
+GO
+
+DECLARE @RoleMember INT;
+SELECT @RoleMember = COUNT(*)
+FROM sys.database_role_members rm
+JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+JOIN sys.database_principals u ON rm.member_principal_id = u.principal_id
+WHERE r.name = N'db_owner' AND u.name = N'gates_user';
+
+IF (@RoleMember = 0)
+BEGIN
+    EXEC sp_addrolemember N'db_owner', N'gates_user';
+END;
+GO

--- a/server/services/dbConfig.ts
+++ b/server/services/dbConfig.ts
@@ -1,12 +1,13 @@
-
 const dbConfig = {
   server: process.env.DB_SERVER,
   user: process.env.DB_USER,
   password: process.env.DB_PASS,
   database: process.env.DB_NAME,
-  port: process.env.DB_PORT
-  // Add other necessary configuration options
+  port: Number(process.env.DB_PORT) || 1433,
+  options: {
+    encrypt: false,
+    trustServerCertificate: true,
+  },
 };
 
 export default dbConfig;
-

--- a/server/services/dbConnect.ts
+++ b/server/services/dbConnect.ts
@@ -1,5 +1,5 @@
 import sql from 'mssql';
-import dbConfig from './dbConfig.js'; // Ensure the path is correct; you may need to adjust it
+import dbConfig from './dbConfig';
 
 export async function getConnection() {
   try {

--- a/server/utils/dbConnect.ts
+++ b/server/utils/dbConnect.ts
@@ -1,5 +1,5 @@
 import sql from 'mssql';
-import dbConfig from './dbConfig.ts'; // Ensure the path is correct; you may need to adjust it
+import dbConfig from '../services/dbConfig';
 
 const pool = new sql.ConnectionPool(dbConfig);
 const poolConnect = pool.connect();


### PR DESCRIPTION
## Summary
- add Docker Compose setup with a SQL Server service and initialization script
- provide a multi-stage Dockerfile and environment template for local development
- document the container workflow and align database configuration defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0e5884fac832383cd1459bf20074a