### PR TITLE
Align Docker, Compose, and deploy workflow for SQL Server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,17 +51,14 @@ jobs:
 
       # --- Deploy to VPS over SSH ---
       - name: SSH into VPS and deploy
-        if: ${{ env.VPS_HOST && env.VPS_USER && env.SSH_PRIVATE_KEY }}
+        if: ${{ secrets.VPS_HOST && secrets.VPS_USER && secrets.SSH_PRIVATE_KEY }}
         uses: appleboy/ssh-action@v0.1.10
-        env:
-          VPS_HOST: ${{ secrets.VPS_HOST }}
-          VPS_USER: ${{ secrets.VPS_USER }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         with:
-          host: ${{ env.VPS_HOST }}
-          username: ${{ env.VPS_USER }}
-          key: ${{ env.SSH_PRIVATE_KEY }}
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd ~/docker/gates-app
+            set -euo pipefail
+            cd ~/docker/gates
             docker compose --profile prod pull
-            docker compose --profile prod up -d
+            docker compose --profile prod up -d --remove-orphans

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use a multi-stage build to support both development and production workflows
+# Multi-stage build supporting development and production workflows
 FROM node:20-alpine AS base
 
 WORKDIR /app
@@ -24,9 +24,8 @@ FROM node:20-alpine AS production
 ENV NODE_ENV=production
 WORKDIR /app
 
-# Copy only what we need for production runtime
-COPY --from=base /app/package*.json ./
-COPY --from=base /app/node_modules ./node_modules
+COPY package*.json ./
+RUN npm ci --omit=dev
 COPY --from=build /app/.output ./.output
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- streamline the Dockerfile so the production image installs only runtime dependencies and runs the Nuxt output
- fix the GitHub Actions deploy workflow to rely on repository secrets and redeploy the compose stack from a consistent path
- rewrite the README with clear environment, Docker Compose, database, and deployment setup instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a009682883239de933f29dfee403