### PR TITLE
Ensure level 4 floors spawn bosses in final rooms

### DIFF
--- a/utils/dungeon.js
+++ b/utils/dungeon.js
@@ -1,0 +1,64 @@
+const DEFAULT_BOSS_NAME = 'Ancient Overlord';
+
+function normalizeRewards(sourceRewards) {
+    if (!Array.isArray(sourceRewards)) {
+        return [];
+    }
+    return sourceRewards.map((reward) => ({ ...reward }));
+}
+
+function createBossEncounter(floor, existingEncounter = {}) {
+    const bossConfig = floor?.boss ?? {};
+
+    const rewardsSource = Array.isArray(bossConfig.rewards)
+        ? bossConfig.rewards
+        : existingEncounter.rewards;
+
+    return {
+        ...existingEncounter,
+        type: 'boss',
+        name: bossConfig.name ?? existingEncounter.name ?? DEFAULT_BOSS_NAME,
+        level: bossConfig.level ?? existingEncounter.level ?? floor?.level ?? 0,
+        rewards: normalizeRewards(rewardsSource ?? []),
+    };
+}
+
+export function ensureBossInLastRoom(floor) {
+    if (!floor || typeof floor !== 'object') {
+        return floor;
+    }
+
+    const { level, rooms } = floor;
+
+    if (level !== 4 || !Array.isArray(rooms) || rooms.length === 0) {
+        return floor;
+    }
+
+    const lastRoom = rooms[rooms.length - 1];
+
+    if (lastRoom?.type === 'boss' && lastRoom?.encounter?.type === 'boss') {
+        return floor;
+    }
+
+    const updatedRooms = rooms.map((room) => ({ ...room }));
+    const existingEncounter = updatedRooms[updatedRooms.length - 1]?.encounter ?? {};
+
+    updatedRooms[updatedRooms.length - 1] = {
+        ...updatedRooms[updatedRooms.length - 1],
+        type: 'boss',
+        encounter: createBossEncounter(floor, existingEncounter),
+    };
+
+    return {
+        ...floor,
+        rooms: updatedRooms,
+    };
+}
+
+export function assignBossesToFloors(floors) {
+    if (!Array.isArray(floors)) {
+        return floors;
+    }
+
+    return floors.map((floor) => ensureBossInLastRoom(floor));
+}

--- a/utils/tests/dungeon.spec.js
+++ b/utils/tests/dungeon.spec.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { assignBossesToFloors, ensureBossInLastRoom } from '../dungeon.js';
+
+describe('ensureBossInLastRoom', () => {
+    it('adds a boss encounter to the last room of a level 4 floor', () => {
+        const floor = {
+            level: 4,
+            boss: {
+                name: 'Storm Hydra',
+                level: 12,
+                rewards: [{ id: 'relic-1', name: 'Relic of Storms' }],
+            },
+            rooms: [
+                { id: 1, type: 'combat' },
+                { id: 2, type: 'treasure' },
+            ],
+        };
+
+        const result = ensureBossInLastRoom(floor);
+
+        expect(result).not.toBe(floor);
+        expect(result.rooms).toHaveLength(2);
+        expect(result.rooms[1]).toMatchObject({
+            id: 2,
+            type: 'boss',
+            encounter: {
+                type: 'boss',
+                name: 'Storm Hydra',
+                level: 12,
+                rewards: [{ id: 'relic-1', name: 'Relic of Storms' }],
+            },
+        });
+
+        // ensure we did not mutate original structure
+        expect(floor.rooms[1].type).toBe('treasure');
+        expect(floor.rooms[1].encounter).toBeUndefined();
+    });
+
+    it('returns the original floor when the boss already exists', () => {
+        const bossRoom = {
+            id: 3,
+            type: 'boss',
+            encounter: {
+                type: 'boss',
+                name: 'Existing Guardian',
+                level: 15,
+                rewards: [{ id: 'gem', name: 'Radiant Gem' }],
+                phases: 2,
+            },
+        };
+
+        const floor = {
+            level: 4,
+            rooms: [{ id: 1, type: 'puzzle' }, bossRoom],
+        };
+
+        const result = ensureBossInLastRoom(floor);
+
+        expect(result).toBe(floor);
+        expect(result.rooms[1]).toBe(bossRoom);
+    });
+
+    it('ignores floors that are not level 4 or without rooms', () => {
+        const emptyFloor = { level: 4, rooms: [] };
+        const lowLevelFloor = { level: 3, rooms: [{ id: 1, type: 'combat' }] };
+
+        expect(ensureBossInLastRoom(emptyFloor)).toBe(emptyFloor);
+        expect(ensureBossInLastRoom(lowLevelFloor)).toBe(lowLevelFloor);
+        expect(ensureBossInLastRoom(null)).toBeNull();
+    });
+});
+
+describe('assignBossesToFloors', () => {
+    it('ensures every level 4 floor has a boss in the last room', () => {
+        const floors = [
+            {
+                level: 4,
+                boss: { name: 'Frost Titan', level: 10 },
+                rooms: [
+                    { id: 'a', type: 'combat' },
+                    { id: 'b', type: 'empty' },
+                ],
+            },
+            {
+                level: 2,
+                rooms: [{ id: 'c', type: 'puzzle' }],
+            },
+        ];
+
+        const result = assignBossesToFloors(floors);
+
+        expect(result[0].rooms[1].type).toBe('boss');
+        expect(result[0].rooms[1].encounter.type).toBe('boss');
+        expect(result[1].rooms[0].type).toBe('puzzle');
+    });
+});


### PR DESCRIPTION
## Summary
- add a dungeon utility that guarantees level 4 floors spawn a boss in their final room
- copy existing encounter data and boss configuration while preserving immutability
- cover the utility with targeted tests for single floors and collections of floors

## Testing
- npx vitest utils/tests/dungeon.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e642512ca883239c61c2809f58e93e